### PR TITLE
Support chrooted/contained processes

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11
+
+ENV PYTHONUNBUFFERED=True
+
+WORKDIR /app
+COPY container-injection.c .
+
+RUN gcc -c -Wall -fpic container-injection.c
+RUN gcc -shared -o libcontainer-injection.so container-injection.o
+
+
+CMD ["bash", "-c", "echo override this; exit 1"]

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,0 +1,4 @@
+
+.PHONY: test
+test:
+	docker compose up --abort-on-container-failure

--- a/integration/container-injection.c
+++ b/integration/container-injection.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+const char *message = "Injected!\n";
+
+__attribute__((constructor))
+static void init()
+{
+    write(1, message, strlen(message));
+    exit(0);
+}

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -1,0 +1,36 @@
+services:
+  target:
+    build:
+      dockerfile: Dockerfile
+    command:
+      - python
+      - -c
+      - |
+        print('started')
+        import time
+        time.sleep(10)
+        print("time's up!")
+        exit(1)
+
+  injector:
+    image: 'python:3.11'
+    pid: host
+    volumes:
+      - ..:/src
+    depends_on:
+      - target
+    working_dir: /src
+    command:
+      - bash
+      - -c
+      - |
+        set -euo pipefail
+        python3 -m venv /tmp/.venv-integration
+        . /tmp/.venv-integration/bin/activate
+        python3 -m pip install .
+        set -euo pipefail  # this is a new shell after the activate
+        sopath=$(ls /proc/*/root/app/libcontainer-injection.so)
+        printf 'sopath="%s"\n' "$$sopath"
+        pid=$(echo "$$sopath" | awk -F / '{print $3}')
+        printf 'pid="%s"\n' "$$pid"
+        inject --process-root "/proc/$$pid/root" "$$pid" /app/libcontainer-injection.so

--- a/pyinjector/__main__.py
+++ b/pyinjector/__main__.py
@@ -10,13 +10,14 @@ def parse_args(args: Optional[List[str]]) -> Namespace:
     parser.add_argument('pid', type=int, help='pid of the process to inject the library into')
     parser.add_argument('library_path', type=str.encode, help='path of the library to inject')
     parser.add_argument('-u', '--uninject', action='store_true', help='Whether to uninject the library after injection')
+    parser.add_argument('--process-root', type=str.encode, help="Path to the target's filesystem root if in a container or chroot jail.")
     return parser.parse_args(args)
 
 
 def main(args: Optional[List[str]] = None) -> None:
     parsed_args = parse_args(args)
     try:
-        handle = inject(parsed_args.pid, parsed_args.library_path, parsed_args.uninject)
+        handle = inject(parsed_args.pid, parsed_args.library_path, parsed_args.uninject, parsed_args.process_root)
     except PyInjectorError as e:
         print(f"pyinjector failed to inject: {e}", file=sys.stderr)
     else:

--- a/tests/pyinjector/test_api.py
+++ b/tests/pyinjector/test_api.py
@@ -1,0 +1,16 @@
+from pytest import mark
+
+from pyinjector.api import self_relative_path
+
+
+@mark.parametrize('library_path,process_root,expected', [
+    (b'/tmp/some/lib.so', '', b'/tmp/some/lib.so'),
+    (b'/tmp/some/lib.so', b'', b'/tmp/some/lib.so'),
+    (b'/tmp/some/lib.so', '/proc/123/root', b'/proc/123/root/tmp/some/lib.so'),
+    (b'/tmp/some/lib.so', '/proc/123/root/', b'/proc/123/root/tmp/some/lib.so'),
+    (b'tmp/some/lib.so', '/proc/123/root', b'/proc/123/root/tmp/some/lib.so'),
+    (b'tmp/some/lib.so', '/proc/123/root/', b'/proc/123/root/tmp/some/lib.so'),
+])
+def test_self_relative_path(library_path, process_root, expected):
+
+    assert self_relative_path(library_path, process_root) == expected


### PR DESCRIPTION
This adds support for injecting libraries into processes in containers. Which is needed for https://github.com/kmaork/hypno/issues/18.

It's draft right now for a few reasons. I've not hooked the tests into the github actions workflows. In fact I'm not sure if I've gone in the right direction with the tests, i.e. using docker compose ?
It looks a bit ugly but I suspect it's less awkward than trying to control containers from within the pytest tests.

```
~/src/third-party/pyinjector/integration (support-chrooted-processes) % make test
docker compose up --abort-on-container-failure
[+] Running 2/0
 ✔ Container integration-target-1    C...                                  0.0s 
 ✔ Container integration-injector-1  Created                               0.0s 
Attaching to injector-1, target-1
target-1    | started
injector-1  | Processing /src
injector-1  |   Installing build dependencies: started
injector-1  |   Installing build dependencies: finished with status 'done'
injector-1  |   Getting requirements to build wheel: started
injector-1  |   Getting requirements to build wheel: finished with status 'done'
injector-1  |   Preparing metadata (pyproject.toml): started
injector-1  |   Preparing metadata (pyproject.toml): finished with status 'done'
injector-1  | Building wheels for collected packages: pyinjector
injector-1  |   Building wheel for pyinjector (pyproject.toml): started
injector-1  |   Building wheel for pyinjector (pyproject.toml): finished with status 'done'
injector-1  |   Created wheel for pyinjector: filename=pyinjector-1.3.0-cp311-cp311-linux_aarch64.whl size=53781 sha256=f385d0a19b69cca7fa0a965f3432e15fcd28c4cd876eb4bd211281dccede6619
injector-1  |   Stored in directory: /tmp/pip-ephem-wheel-cache-d6s_wou4/wheels/a0/a1/77/062e875f5b546d9255c4403d3277b732c25c5e17cdbf8d14d3
injector-1  | Successfully built pyinjector
injector-1  | Installing collected packages: pyinjector
injector-1  |   Attempting uninstall: pyinjector
injector-1  |     Found existing installation: pyinjector 1.3.0
injector-1  |     Uninstalling pyinjector-1.3.0:
injector-1  |       Successfully uninstalled pyinjector-1.3.0
injector-1  | Successfully installed pyinjector-1.3.0
injector-1  | 
injector-1  | [notice] A new release of pip is available: 24.0 -> 24.1.2
injector-1  | [notice] To update, run: pip install --upgrade pip
injector-1  | sopath="/proc/28976/root/app/libcontainer-injection.so"
injector-1  | pid="28976"
target-1    | Injected!
injector-1  | pyinjector failed to inject: Injector failed with -1 calling injector_inject: The target process unexpectedly terminated with exit code 0.
target-1 exited with code 0
injector-1 exited with code 0
```


Secondly, I've not yet tried incorporating your suggestion
> but I think that it'd also be useful to always check for existence of the shared library in the target process' fs (again using `/proc/pid/root`) by default.

I think that it shouldn't be too hard to iterate on with the tests set up though.

Also, if you like some of this and dislike other bits I'm completely unattached to it.
